### PR TITLE
calc_band_plot

### DIFF
--- a/src/Plotfuncs.jl
+++ b/src/Plotfuncs.jl
@@ -158,7 +158,7 @@ module Plotfuncs
         numlines = klines.numlines
         dim = lattice.dim-1
         klength = 0.0
-        vec_k = []
+        vec_k = Float64[]
         numatoms = lattice.numatoms
         N = numatoms*nsites
         energies = zeros(Float64,0,N)


### PR DESCRIPTION
`calc_band_plot` function failed at https://github.com/cometscome/TightBinding.jl/blob/master/src/Plotfuncs.jl#L150
because `vec_k` of the type `Array{Any,1}` are not valid series (number) data for `plot` function.

Initialize `vec_k` with `Float64[]` rather than  `[]` to allow the conversion.
